### PR TITLE
UIFixes Compat: Decouple Operations from Sending; Support Rollback

### DIFF
--- a/MC_Food_Operation.cs
+++ b/MC_Food_Operation.cs
@@ -1,14 +1,15 @@
 ﻿using EFT.InventoryLogic;
-using System;
 
 namespace MergeConsumables
 {
 	public class MC_Food_Operation : IExecute, IRaiseEvents, GInterface339, GInterface343, GInterface347
 	{
-		public MC_Food_Operation(Item item, Item targetItem, TraderControllerClass itemController)
+		public MC_Food_Operation(FoodClass item, FoodClass targetItem, float count, GStruct414<GClass2799> discard, TraderControllerClass itemController)
 		{
 			this.item = item;
 			this.targetItem = targetItem;
+			this.count = count;
+			this.discard = discard;
 			this.itemController = itemController;
 		}
 
@@ -19,8 +20,6 @@ namespace MergeConsumables
 				return item;
 			}
 		}
-
-		private readonly Item item;
 
 		public Item ResultItem
 		{
@@ -46,12 +45,15 @@ namespace MergeConsumables
 			}
 		}
 
-		private readonly Item targetItem;
+		private readonly FoodClass item;
+		private readonly FoodClass targetItem;
+		private readonly float count;
 		private readonly TraderControllerClass itemController;
+		private readonly GStruct414<GClass2799> discard;
 
 		public bool CanExecute(TraderControllerClass itemController)
 		{
-			if (item is FoodClass && targetItem is FoodClass)
+			if (item != null && targetItem != null)
 			{
 				if (item.TemplateId == targetItem.TemplateId)
 				{
@@ -64,18 +66,36 @@ namespace MergeConsumables
 
 		public GStruct413 Execute()
 		{
-			return InteractionsHandlerClassExtensions.MergeFood((FoodClass)item, (FoodClass)targetItem, itemController, false);
+			return InteractionsHandlerClassExtensions.MergeFood(item, targetItem, count, itemController, false);
 		}
 
 		public void RaiseEvents(TraderControllerClass controller, CommandStatus status)
 		{
-			item.RaiseRefreshEvent(false, true);
+			if (discard.Succeeded && discard.Value != null)
+			{
+				discard.Value.RaiseEvents(controller, status);
+			}
+			else
+			{
+				item.RaiseRefreshEvent(false, true);
+			}
+
 			targetItem.RaiseRefreshEvent(false, true);
 		}
 
 		public void RollBack()
 		{
-			throw new NotImplementedException();
+			if (discard.Succeeded && discard.Value != null)
+			{
+				discard.Value.RollBack();
+			}
+
+			InteractionsHandlerClassExtensions.MergeFood(targetItem, item, count, itemController, false);
+		}
+
+		public CombineItemsModel ToCombineItemsModel()
+		{
+			return new CombineItemsModel(item.Id, targetItem.Id, item.FoodDrinkComponent.HpPercent, targetItem.FoodDrinkComponent.HpPercent, "food");
 		}
 	}
 }

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.1.0")]


### PR DESCRIPTION
Ending up being slightly more involved, but it's half the code it looks like, since Meds and Food code are similar.

The operations hold more data now, enough to raise events (now including the discard event) and to rollback.

The interaction handler methods now do the work and then rollback if `simulate == true`. The method takes the amount to transfer, with 0 meaning to do max. This is the same model that BSG's merge/transfer code has. It allows the rollback method to call the same code, just swap `item` and `targetItem`. 

Sending is moved to a patch of `RunNetworkTransaction`, which executes it with `simulate = false` and raises the events.

I also simplified a few things, like the actual transfer is just math now, instead of the loop.